### PR TITLE
Swapped out docopt for docopt-ng, removed use of distutils

### DIFF
--- a/pynitf/docopt_simple.py
+++ b/pynitf/docopt_simple.py
@@ -1,11 +1,10 @@
-from builtins import object
-from docopt import *
-import sys
 import re
-import os
 
-class DocOptSimple(object):
-    '''The package docopt (http://docopt.org) is a nice package,
+from docopt import docopt
+
+
+class DocOptSimple:
+    """The package docopt (http://docopt.org) is a nice package,
     but it has the disadvantage that getting the options etc. from it
     uses a somewhat unnatural interface (e.g., --my-opt=n comes as
     int(d["--my-opt"]) rather than OptionParser cleaner sort of
@@ -14,24 +13,26 @@ class DocOptSimple(object):
     "my_val", we first look for the argument "my_val", then "<my_val>",
     then "--my_val", then "--my-val". If the value looks like a integer,
     we return it to an integer. If it looks like a float, we return it to
-    a float. If we don't otherwise recognize it, we return this as a string.'''
-    def __init__(self, doc, argv=None, help=True, version=None, 
-                 options_first=False):
-        self.args = docopt(doc, argv=argv, help=help, version=version, 
-                           options_first=options_first)
+    a float. If we don't otherwise recognize it, we return this as a string."""
+
+    def __init__(self, doc, argv=None, help=True, version=None, options_first=False):
+        self.args = docopt(
+            doc,
+            argv=argv,
+            default_help=help,
+            version=version,
+            options_first=options_first,
+        )
 
     def __getstate__(self):
-        return { "args" : self.args }
+        return {"args": self.args}
 
-    def __setstate__(self,dict):
+    def __setstate__(self, dict):
         self.args = dict["args"]
-        
+
     def __contains__(self, name):
-        for key in (name, 
-                    "<" + name + ">", 
-                    "--" + name,
-                    "--" + name.replace("_", "-")):
-            if(key in self.args):
+        for key in (name, "<" + name + ">", "--" + name, "--" + name.replace("_", "-")):
+            if key in self.args:
                 return True
         return False
 
@@ -42,41 +43,40 @@ class DocOptSimple(object):
         if name == "args":
             self.args = {}
             return self.args
-        for key in (name, 
-                    "<" + name + ">", 
-                    "--" + name,
-                    "--" + name.replace("_", "-")):
-            if(key in self.args):
+        for key in (name, "<" + name + ">", "--" + name, "--" + name.replace("_", "-")):
+            if key in self.args:
                 return self.__find_type(key)
         raise AttributeError(name)
 
     def __find_type(self, key):
-        '''Find the type of the value, and return in'''
+        """Find the type of the value, and return in"""
         v = self.args[key]
-        if(isinstance(v, str)):
-            if(re.match(r'[+-]?\d+$', v)):
+        if isinstance(v, str):
+            if re.match(r"[+-]?\d+$", v):
                 return int(v)
-            if(re.match(r'[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$', v)):
+            if re.match(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$", v):
                 return float(v)
-            if(re.match(r'[-+]?[0-9]+\.([eE][-+]?[0-9]+)?$', v)):
+            if re.match(r"[-+]?[0-9]+\.([eE][-+]?[0-9]+)?$", v):
                 return float(v)
         return v
-    
-def docopt_simple(doc, argv=None, help=True, version=None, 
-                  options_first=False):
-    '''The package docopt (http://docopt.org) is a nice package,
+
+
+def docopt_simple(doc, argv=None, help=True, version=None, options_first=False):
+    """The package docopt (http://docopt.org) is a nice package,
     but it has the disadvantage that getting the options etc. from it
     uses a somewhat unnatural interface. This gives a simpler interface
     sufficient for many programs. See DocOptSimple class for details
-    on the interface.'''
+    on the interface."""
 
-    return DocOptSimple(doc, argv=argv, help=help, version=version, 
-                        options_first=options_first)
+    return DocOptSimple(
+        doc, argv=argv, help=help, version=version, options_first=options_first
+    )
+
 
 # Don't export this. We normally get docopt_simple from other modules
 # (e.g., geocal), but we want to have a copy around for stand alone
 # programs. We import this, but not export it. The stand alone programs
 # use full path to get this.
 
-#__all__ = ["docopt_simple"]
-__all__ = [ ]
+# __all__ = ["docopt_simple"]
+__all__ = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-docopt
+docopt-ng
 # h5py isn't strictly required, without this there is just a few
 # functions that aren't implemented
 h5py

--- a/setup.py
+++ b/setup.py
@@ -3,20 +3,25 @@ from setuptools import setup
 # Version moved to pynitf/version.py so we have one place it is defined.
 exec(open("pynitf/version.py").read())
 
-setup(name='pynitf',
-      version=__version__,
-      description='This is a package for reading and writing NITF',
-      url='https://github.jpl.nasa.gov/Cartography/pynitf',
-      author='Mike Smyth <Mike.M.Smyth@jpl.nasa.gov>, Philip Yoon <Philip.J.Yoon@jpl.nasa.gov>',
-      author_email='Mike.M.Smyth@jpl.nasa.gov',
-      license='Copyright 2020, California Institute of Technology. ALL RIGHTS RESERVED. U.S. Government Sponsorship acknowledged.',
-      packages=['pynitf'],
-      scripts=["bin/nitf_diff", "bin/nitf_info", "bin/nitf_json_delta",
-               "bin/explore_nitf"],
-      install_requires=[
-          'numpy',
-          'docopt'
-      ],
-      setup_requires=["pytest-runner",],
-      tests_requires=["pytest","h5py"],
-      zip_safe=False)
+setup(
+    name="pynitf",
+    version=__version__,
+    description="This is a package for reading and writing NITF",
+    url="https://github.jpl.nasa.gov/Cartography/pynitf",
+    author="Mike Smyth <Mike.M.Smyth@jpl.nasa.gov>, Philip Yoon <Philip.J.Yoon@jpl.nasa.gov>",
+    author_email="Mike.M.Smyth@jpl.nasa.gov",
+    license="Copyright 2020, California Institute of Technology. ALL RIGHTS RESERVED. U.S. Government Sponsorship acknowledged.",
+    packages=["pynitf"],
+    scripts=[
+        "bin/nitf_diff",
+        "bin/nitf_info",
+        "bin/nitf_json_delta",
+        "bin/explore_nitf",
+    ],
+    install_requires=["numpy", "docopt-ng"],
+    setup_requires=[
+        "pytest-runner",
+    ],
+    tests_requires=["pytest", "h5py"],
+    zip_safe=False,
+)


### PR DESCRIPTION
This PR swaps out the `docopt` dependency for a maintained fork of it called `docopt-ng` to avoid future `SyntaxErrors` raised by an improper use of escape sequences in regex patterns. The only code change related to the swap was to change an argument name into `docopt.docopt` from `help` to `default_help`

Additionally, in order to support maintenance of the repo with newer python versions, the use of distutils in `tests/pynitf_test_support/pynitf_test_support.py` was removed and the function call replaced with a call to `shutil.copytree` instead. 

I ran the tests and they all pass except for some that are skipped. I also ran some of the utilities scripts in `bin/` and they seemed to work fine after the swap.  

Resolves #2 